### PR TITLE
Fix deprecation warning for `Redis.current`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.1.2"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
+gem "connection_pool"
 gem "puma", require: false
 gem "redis-objects"
 gem "rollbar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     byebug (11.1.3)
     coderay (1.1.3)
+    connection_pool (2.2.5)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -80,6 +81,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  connection_pool
   coveralls
   dotenv
   foreman

--- a/app.rb
+++ b/app.rb
@@ -20,7 +20,7 @@ class App < Sinatra::Base
   end
 
   before do
-    Redis.current = Redis.new(url: ENV["REDIS_URL"])
+    Redis::Objects.redis = ConnectionPool.new(size: 5, timeout: 5) { Redis.new(url: ENV["REDIS_URL"]) }
   end
 
   get "/" do


### PR DESCRIPTION
```
`Redis.current=` is deprecated and will be removed in 5.0.
```