### PR TITLE
Fix deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /app
 COPY Gemfile Gemfile.lock /app/
 
 RUN bundle config set --local jobs 2 && \
-    bundle install --without=development test --deployment
+    bundle config set --local deployment 'true' && \
+    bundle config set --local without 'development test' && \
+    bundle install
 
 COPY . .
 


### PR DESCRIPTION
```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local deployment 'true'`, and stop using this flag
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local without 'development test'`, and stop using this flag
```