### PR TITLE
Removed a colon in the message

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -51,11 +51,11 @@ class App < Sinatra::Base
         case event["subtype"]
         when "add"
           emoji_name = event["name"]
-          message = "A new emoji is added :#{emoji_name}: `:#{emoji_name}:`"
+          message = "A new emoji is added :#{emoji_name}: `#{emoji_name}`"
 
           if event["value"].start_with?("alias:")
             origin_emoji = event["value"].gsub(/^alias:/, "")
-            message << " (alias of `:#{origin_emoji}:`)"
+            message << " (alias of `#{origin_emoji}`)"
           end
 
           if App.enabled_redis?

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -21,7 +21,7 @@ describe App do
     context "when emoji_changed" do
       context "when add" do
         let(:payload) { fixture("emoji_changed_add.json") }
-        let(:message) { "A new emoji is added :picard_facepalm: `:picard_facepalm:`" }
+        let(:message) { "A new emoji is added :picard_facepalm: `picard_facepalm`" }
 
         context "called once" do
           it { should be_ok }
@@ -93,7 +93,7 @@ describe App do
         it "post_slack is called" do
           subject
 
-          message = "A new emoji is added :picard_facepalm_alias: `:picard_facepalm_alias:` (alias of `:picard_facepalm:`)"
+          message = "A new emoji is added :picard_facepalm_alias: `picard_facepalm_alias` (alias of `picard_facepalm`)"
           expect(App).to have_received(:post_slack).with(message)
         end
       end


### PR DESCRIPTION
In Android apps, `:xxxx:` is expanded as an emoji.