### PR TITLE
[CVE-2023-36617] Upgrade to uri 0.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "redis-objects"
 gem "sentry-ruby"
 gem "sinatra-contrib", ">= 2.2.0"
 gem "slack-notifier", ">= 2.4.0"
+gem "uri", ">= 0.12.2" # for CVE-2023-36617
 
 group :development do
   gem "dotenv", require: "dotenv/load"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    uri (0.12.2)
 
 PLATFORMS
   ruby
@@ -164,6 +165,7 @@ DEPENDENCIES
   simplecov
   sinatra-contrib (>= 2.2.0)
   slack-notifier (>= 2.4.0)
+  uri (>= 0.12.2)
 
 BUNDLED WITH
    2.3.7


### PR DESCRIPTION
ref. https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/