### PR TITLE
Fix deprecation warning in simplecov v1

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ if ENV["CI"]
   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
   SimpleCov.start do
     %w[spec].each do |ignore_path|
-      add_filter(ignore_path)
+      skip(ignore_path)
     end
   end
 end


### PR DESCRIPTION
```
/home/runner/work/emoy_webhook/emoy_webhook/spec/spec_helper.rb:8:in 'block (2 levels) in <top (required)>': [DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior). Example: `SimpleCov.skip "spec"`.
```